### PR TITLE
removing some funky quotes from line output

### DIFF
--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -59,7 +59,7 @@ module Marginalia
           if last_line.starts_with? root
             last_line = last_line[root.length..-1]
           end
-          last_line
+          last_line.gsub('`', '').gsub('\'', '')
         end
       end
 

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -88,7 +88,7 @@ class MarginaliaTest < Test::Unit::TestCase
     # Because "lines_to_ignore" by default includes "marginalia" and "gem", the
     # extracted line line will be from the line in this file that actually
     # triggers the query.
-    assert_match %r{/\*line:test/query_comments_test.rb:[0-9]+:in `driver_only'\*/$}, @queries.first
+    assert_match %r{/\*line:test/query_comments_test.rb:[0-9]+:in driver_only\*/$}, @queries.first
   end
 
   def test_last_line_component_with_lines_to_ignore


### PR DESCRIPTION
These quotes cause NewRelic SQL obfuscation to fail
